### PR TITLE
Use UMD CDN for Lucide icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,9 @@
     </script>
 
     <!-- Lucide Icons -->
-    <script src="https://unpkg.com/lucide-react@0.292.0/dist/umd/lucide-react.js"></script>
-    
+    <script src="https://cdn.jsdelivr.net/npm/lucide-react@0.292.0/dist/umd/lucide-react.min.js"></script>
+    <script>window.lucide = window.lucideReact;</script>
+
     <!-- App Code -->
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load Lucide from jsDelivr UMD build
- expose `window.lucide` alias for lucide-react

## Testing
- `npm test` (fails: Error: no test specified)
- `node -e using Playwright to open index.html` *(failed to load external resources; no `lucide` or `forwardRef` errors observed)*

------
https://chatgpt.com/codex/tasks/task_e_68920a3e1e90832f8d3a7f70ddb4f87f