### PR TITLE
fix: load lucide-react properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
     <!-- React Libraries -->
     <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script>
+        // lucide-react expects a global `react` variable
+        window.react = window.React;
+    </script>
     <style>
         body { font-family: 'Inter', sans-serif; }
     </style>
@@ -37,7 +41,10 @@
 
     <!-- Lucide Icons -->
     <script src="https://cdn.jsdelivr.net/npm/lucide-react@0.292.0/dist/umd/lucide-react.min.js"></script>
-    <script>window.lucide = window.lucideReact;</script>
+    <script>
+        // expose lucide-react components under the `lucide` global
+        window.lucide = window.LucideReact;
+    </script>
 
     <!-- App Code -->
     <script src="app.js"></script>


### PR DESCRIPTION
## Summary
- expose React as `react` global
- assign `LucideReact` to `lucide` global so icons can render

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_689215bebc20832f9cb116014cf1bc2c