### PR TITLE
feat: improve firestore sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -437,6 +437,7 @@ const TodoApp = ({
   const [editingPriorityId, setEditingPriorityId] = useState(null);
   useEffect(() => {
     if (!user) return;
+    setIsLoading(true);
     const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
     const q = query(sheetsCollectionRef, orderBy('createdAt'));
     const unsubscribe = onSnapshot(q, snapshot => {
@@ -513,10 +514,14 @@ const TodoApp = ({
     return groups;
   }, [sheets]);
   const updateSheet = async (sheetId, updates) => {
-    const sheetRef = doc(db, 'users', user.uid, 'sheets', sheetId);
-    await setDoc(sheetRef, updates, {
-      merge: true
-    });
+    try {
+      const sheetRef = doc(db, 'users', user.uid, 'sheets', sheetId);
+      await setDoc(sheetRef, updates, {
+        merge: true
+      });
+    } catch (err) {
+      console.error('Failed to update sheet', err);
+    }
   };
   const handleItemUpdate = (itemId, updates, targetSheetId) => {
     const sheetToUpdateId = targetSheetId || activeSheetId;
@@ -612,23 +617,27 @@ const TodoApp = ({
     // ... (condensed for brevity)
   };
   const handleAddSheet = async () => {
-    const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
-    const newSheet = {
-      title: 'Nytt Ark',
-      items: [{
-        id: generateId(),
-        content: '',
-        completed: false,
-        indent: 0,
-        deadline: null,
-        notes: '',
-        isHighlighted: false
-      }],
-      archivedItems: [],
-      createdAt: serverTimestamp()
-    };
-    const docRef = await addDoc(sheetsCollectionRef, newSheet);
-    setActiveSheetId(docRef.id);
+    try {
+      const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
+      const newSheet = {
+        title: 'Nytt Ark',
+        items: [{
+          id: generateId(),
+          content: '',
+          completed: false,
+          indent: 0,
+          deadline: null,
+          notes: '',
+          isHighlighted: false
+        }],
+        archivedItems: [],
+        createdAt: serverTimestamp()
+      };
+      const docRef = await addDoc(sheetsCollectionRef, newSheet);
+      setActiveSheetId(docRef.id);
+    } catch (err) {
+      console.error('Failed to add sheet', err);
+    }
   };
   const handleNavigate = (sheetId, itemId) => {
     setActiveSheetId(sheetId);

--- a/app.jsx
+++ b/app.jsx
@@ -218,6 +218,7 @@
 
             useEffect(() => {
                 if (!user) return;
+                setIsLoading(true);
                 const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
                 const q = query(sheetsCollectionRef, orderBy('createdAt'));
 
@@ -273,8 +274,12 @@
             }, [sheets]);
 
             const updateSheet = async (sheetId, updates) => {
-                const sheetRef = doc(db, 'users', user.uid, 'sheets', sheetId);
-                await setDoc(sheetRef, updates, { merge: true });
+                try {
+                    const sheetRef = doc(db, 'users', user.uid, 'sheets', sheetId);
+                    await setDoc(sheetRef, updates, { merge: true });
+                } catch (err) {
+                    console.error('Failed to update sheet', err);
+                }
             };
 
             const handleItemUpdate = (itemId, updates, targetSheetId) => {
@@ -351,15 +356,19 @@
             };
 
             const handleAddSheet = async () => {
-                const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
-                const newSheet = {
-                    title: 'Nytt Ark',
-                    items: [{ id: generateId(), content: '', completed: false, indent: 0, deadline: null, notes: '', isHighlighted: false }],
-                    archivedItems: [],
-                    createdAt: serverTimestamp()
-                };
-                const docRef = await addDoc(sheetsCollectionRef, newSheet);
-                setActiveSheetId(docRef.id);
+                try {
+                    const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
+                    const newSheet = {
+                        title: 'Nytt Ark',
+                        items: [{ id: generateId(), content: '', completed: false, indent: 0, deadline: null, notes: '', isHighlighted: false }],
+                        archivedItems: [],
+                        createdAt: serverTimestamp()
+                    };
+                    const docRef = await addDoc(sheetsCollectionRef, newSheet);
+                    setActiveSheetId(docRef.id);
+                } catch (err) {
+                    console.error('Failed to add sheet', err);
+                }
             };
 
             const handleNavigate = (sheetId, itemId) => {


### PR DESCRIPTION
## Summary
- start sheet listener with loading state and onSnapshot to sync Firestore data
- add error handling for sheet updates and creation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689230bcfe10832f9b9e6e1d88a93bd8