### PR TITLE
fix: ensure default sheets are saved before rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -440,7 +440,7 @@ const TodoApp = ({
     setIsLoading(true);
     const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
     const q = query(sheetsCollectionRef, orderBy('createdAt'));
-    const unsubscribe = onSnapshot(q, snapshot => {
+    const unsubscribe = onSnapshot(q, async snapshot => {
       if (snapshot.empty) {
         const defaultSheets = [{
           title: 'Jobb',
@@ -469,7 +469,7 @@ const TodoApp = ({
           archivedItems: [],
           createdAt: serverTimestamp()
         }];
-        defaultSheets.forEach(sheet => addDoc(sheetsCollectionRef, sheet));
+        await Promise.all(defaultSheets.map(sheet => addDoc(sheetsCollectionRef, sheet)));
       } else {
         const sheetsData = snapshot.docs.map(doc => ({
           id: doc.id,
@@ -612,7 +612,6 @@ const TodoApp = ({
       setActiveId(newItem.id);
       return;
     }
-
     switch (e.key) {
       case 'Tab':
         e.preventDefault();

--- a/app.jsx
+++ b/app.jsx
@@ -222,13 +222,13 @@
                 const sheetsCollectionRef = collection(db, 'users', user.uid, 'sheets');
                 const q = query(sheetsCollectionRef, orderBy('createdAt'));
 
-                const unsubscribe = onSnapshot(q, (snapshot) => {
+                const unsubscribe = onSnapshot(q, async (snapshot) => {
                     if (snapshot.empty) {
                         const defaultSheets = [
                             { title: 'Jobb', items: [{ id: generateId(), content: '# Projekt: Lansera ny Hemsida (Q4)', completed: false, indent: 0, deadline: null, notes: '', isHighlighted: false }], archivedItems: [], createdAt: serverTimestamp() },
                             { title: 'Privat', items: [{ id: generateId(), content: '# Personliga mål', completed: false, indent: 0, deadline: null, notes: '', isHighlighted: false }], archivedItems: [], createdAt: serverTimestamp() }
                         ];
-                        defaultSheets.forEach(sheet => addDoc(sheetsCollectionRef, sheet));
+                        await Promise.all(defaultSheets.map(sheet => addDoc(sheetsCollectionRef, sheet)));
                     } else {
                         const sheetsData = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
                         setSheets(sheetsData);


### PR DESCRIPTION
## Summary
- await initial default sheet creation in Firestore before updating state
- rebuild compiled `app.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689234ffd8e8832f83e088360962ba8a