### PR TITLE
Ensure Firebase auth persists across reloads

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,13 +29,15 @@ const {
 const {
   initializeApp
 } = firebase.app;
-const {
-  getAuth,
-  GoogleAuthProvider,
-  signInWithPopup,
-  onAuthStateChanged,
-  signOut
-} = firebase.auth;
+  const {
+    getAuth,
+    GoogleAuthProvider,
+    signInWithPopup,
+    onAuthStateChanged,
+    signOut,
+    setPersistence,
+    browserLocalPersistence
+  } = firebase.auth;
 const {
   getFirestore,
   collection,
@@ -61,9 +63,10 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+  const app = initializeApp(firebaseConfig);
+  const auth = getAuth(app);
+  setPersistence(auth, browserLocalPersistence).catch(err => console.error('Failed to set auth persistence', err));
+  const db = getFirestore(app);
 
 // --- Helper functions ---
 const generateId = () => doc(collection(db, 'temp')).id;

--- a/app.jsx
+++ b/app.jsx
@@ -5,7 +5,7 @@
         // --- Firebase SDKs ---
         // These are ESM modules, so we need to import them from the global Firebase object
         const { initializeApp } = firebase.app;
-        const { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut } = firebase.auth;
+        const { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut, setPersistence, browserLocalPersistence } = firebase.auth;
         const { getFirestore, collection, onSnapshot, doc, setDoc, addDoc, deleteDoc, query, orderBy, serverTimestamp } = firebase.firestore;
 
         // User's Firebase Configuration
@@ -22,6 +22,7 @@
         // Initialize Firebase
         const app = initializeApp(firebaseConfig);
         const auth = getAuth(app);
+        setPersistence(auth, browserLocalPersistence).catch(err => console.error('Failed to set auth persistence', err));
         const db = getFirestore(app);
 
         // --- Helper functions ---

--- a/index.html
+++ b/index.html
@@ -28,13 +28,13 @@
     <!-- Firebase SDKs -->
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-app.js";
-        import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
+        import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut, setPersistence, browserLocalPersistence } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
         import { getFirestore, collection, onSnapshot, doc, setDoc, addDoc, deleteDoc, query, orderBy, serverTimestamp } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js";
 
         // Make firebase available globally for the app script
         window.firebase = {
             app: { initializeApp },
-            auth: { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut },
+            auth: { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut, setPersistence, browserLocalPersistence },
             firestore: { getFirestore, collection, onSnapshot, doc, setDoc, addDoc, deleteDoc, query, orderBy, serverTimestamp }
         };
     </script>


### PR DESCRIPTION
## Summary
- expose `setPersistence` and `browserLocalPersistence` from Firebase auth and apply them when initializing the app
- keep the JSX source in sync with the compiled JS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892383e9ad0832f9bddf73591a3f14d