### PR TITLE
Add version footer and improve saving robustness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tomt-ark",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- translate footer instructions to English and display site version
- harden Firestore saving with retries and user alert
- bump package version to 0.1.0

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68923fc40650832f876dd5acef15f29e