### PR TITLE
fix: restore archive/delete and bump version

### DIFF
--- a/app.js
+++ b/app.js
@@ -538,6 +538,23 @@ const TodoApp = ({
       items: newItems
     });
   };
+  const findItemBlock = (itemList, id) => {
+    const startIndex = (itemList || []).findIndex(i => i.id === id);
+    if (startIndex === -1) return null;
+    const startItem = itemList[startIndex];
+    let endIndex = startIndex;
+    for (let i = startIndex + 1; i < itemList.length; i++) {
+      if (itemList[i].indent > startItem.indent) {
+        endIndex = i;
+      } else {
+        break;
+      }
+    }
+    return {
+      startIndex,
+      endIndex
+    };
+  };
   const handleArchive = async id => {
     const block = findItemBlock(activeSheet.items, id);
     if (!block) return;

--- a/app.jsx
+++ b/app.jsx
@@ -292,6 +292,21 @@
                 await updateSheet(sheetToUpdateId, { items: newItems });
             };
 
+            const findItemBlock = (itemList, id) => {
+                const startIndex = (itemList || []).findIndex(i => i.id === id);
+                if (startIndex === -1) return null;
+                const startItem = itemList[startIndex];
+                let endIndex = startIndex;
+                for (let i = startIndex + 1; i < itemList.length; i++) {
+                    if (itemList[i].indent > startItem.indent) {
+                        endIndex = i;
+                    } else {
+                        break;
+                    }
+                }
+                return { startIndex, endIndex };
+            };
+
             const handleArchive = async (id) => {
                 const block = findItemBlock(activeSheet.items, id);
                 if (!block) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tomt-ark",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tomt-ark",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tomt-ark",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- reintroduce item block finder to allow archive and delete operations
- bump version to 0.1.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68927413d948832fb4d7ef6165ce44d4