### PR TITLE
feat: add undo redo and tab switch shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tomt-ark",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tomt-ark",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tomt-ark",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- add undo/redo history for item edits
- support Cmd+Alt+Arrow to switch tabs
- document new shortcuts and bump version to 0.1.2

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892940b72a8832f95809ba29a079f1d