### PR TITLE
fix: preserve caret while editing items

### DIFF
--- a/app.js
+++ b/app.js
@@ -530,13 +530,18 @@ const TodoApp = ({
   };
   const handleItemUpdate = async (itemId, updates, targetSheetId) => {
     const sheetToUpdateId = targetSheetId || activeSheetId;
-    const sheet = sheets.find(s => s.id === sheetToUpdateId);
-    if (!sheet) return;
+    const sheetIndex = sheets.findIndex(s => s.id === sheetToUpdateId);
+    if (sheetIndex === -1) return;
+    const sheet = sheets[sheetIndex];
     const prevItems = sheet.items || [];
     const newItems = prevItems.map(item => item.id === itemId ? {
       ...item,
       ...updates
     } : item);
+    setSheets(prevSheets => prevSheets.map((s, idx) => idx === sheetIndex ? {
+      ...s,
+      items: newItems
+    } : s));
     setHistory(h => [...h, {
       sheetId: sheetToUpdateId,
       items: prevItems
@@ -960,7 +965,7 @@ const TodoApp = ({
     className: "font-bold"
   }, "Shortcuts:"), " Enter, Tab, Arrows, Backspace, Cmd+Alt+Arrow Tabs, Cmd+Z Undo, Cmd+Shift+Z Redo"), /*#__PURE__*/React.createElement("p", {
     className: "mt-1"
-  }, "Tomt Ark by Turbin v0.1.2"))));
+  }, "Tomt Ark by Turbin v0.1.3"))));
 };
 
 // --- Top-level Component to handle Auth State ---

--- a/app.jsx
+++ b/app.jsx
@@ -287,11 +287,14 @@
 
             const handleItemUpdate = async (itemId, updates, targetSheetId) => {
                 const sheetToUpdateId = targetSheetId || activeSheetId;
-                const sheet = sheets.find(s => s.id === sheetToUpdateId);
-                if (!sheet) return;
+                const sheetIndex = sheets.findIndex(s => s.id === sheetToUpdateId);
+                if (sheetIndex === -1) return;
 
+                const sheet = sheets[sheetIndex];
                 const prevItems = sheet.items || [];
                 const newItems = prevItems.map(item => item.id === itemId ? { ...item, ...updates } : item);
+
+                setSheets(prevSheets => prevSheets.map((s, idx) => idx === sheetIndex ? { ...s, items: newItems } : s));
                 setHistory(h => [...h, { sheetId: sheetToUpdateId, items: prevItems }]);
                 setFuture([]);
                 await updateSheet(sheetToUpdateId, { items: newItems });
@@ -584,7 +587,7 @@
                         )}
                         <div className="text-xs text-gray-400 mt-6 text-center px-4">
                             <p><span className="font-bold">Markdown:</span> # Heading | **Bold** | *Italic* | !1 - !5 Priority &nbsp;&nbsp;·&nbsp;&nbsp; <span className="font-bold">Shortcuts:</span> Enter, Tab, Arrows, Backspace, Cmd+Alt+Arrow Tabs, Cmd+Z Undo, Cmd+Shift+Z Redo</p>
-                            <p className="mt-1">Tomt Ark by Turbin v0.1.2</p>
+                            <p className="mt-1">Tomt Ark by Turbin v0.1.3</p>
                         </div>
                     </div>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tomt-ark",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tomt-ark",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tomt-ark",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- ensure edited items update local state before sending to Firestore so caret stays in place
- bump version to 0.1.3 and update footer text

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_689303518d6c832f940dce0c21da91b0